### PR TITLE
Put response body to the error message in case of invalid consul status

### DIFF
--- a/src/main/java/io/vertx/ext/consul/impl/ConsulClientImpl.java
+++ b/src/main/java/io/vertx/ext/consul/impl/ConsulClientImpl.java
@@ -730,7 +730,9 @@ public class ConsulClientImpl implements ConsulClient {
           }
           resultHandler.handle(Future.succeededFuture(mapped));
         } else {
-          resultHandler.handle(Future.failedFuture(resp.statusMessage()));
+          resultHandler.handle(Future.failedFuture(
+            String.format("Status message: '%s'. Body: '%s' ", resp.statusMessage(), resp.bodyAsString()))
+          );
         }
       } else {
         resultHandler.handle(Future.failedFuture(h.cause()));


### PR DESCRIPTION
Error messages such as `io.vertx.core.impl.NoStackTraceThrowable: Internal Server Error` is not so informative when it comes to figuring out what goes wrong. 