### PR TITLE
Fix watch close order

### DIFF
--- a/src/main/java/io/vertx/ext/consul/impl/WatchImpl.java
+++ b/src/main/java/io/vertx/ext/consul/impl/WatchImpl.java
@@ -169,7 +169,7 @@ public abstract class WatchImpl<T> implements Watch<T> {
       throw new IllegalStateException("Watch already stopped");
     }
     stopped = true;
-    vertx.runOnContext(v -> consulClient.close());
+    consulClient.close();
   }
 
   private void go() {


### PR DESCRIPTION
Fix exception "Unhandled exception java.lang.IllegalStateException: Client is closed" on undeploy verticle