### PR TITLE
Issue #76. Added 'header' field support for Consul checks

### DIFF
--- a/src/main/java/io/vertx/ext/consul/CheckOptions.java
+++ b/src/main/java/io/vertx/ext/consul/CheckOptions.java
@@ -19,6 +19,7 @@ import io.vertx.codegen.annotations.DataObject;
 import io.vertx.core.json.JsonObject;
 
 import java.util.List;
+import java.util.Map;
 
 /**
  * Options used to register checks in Consul.
@@ -32,6 +33,7 @@ public class CheckOptions {
   private String name;
   private List<String> scriptArgs;
   private String http;
+  private Map<String, List<String>> header;
   private String ttl;
   private String tcp;
   private String grpc;
@@ -59,6 +61,7 @@ public class CheckOptions {
     this.name = options.name;
     this.scriptArgs = options.scriptArgs;
     this.http = options.http;
+    this.header = options.header;
     this.ttl = options.ttl;
     this.tcp = options.tcp;
     this.interval = options.interval;
@@ -162,6 +165,26 @@ public class CheckOptions {
    */
   public CheckOptions setHttp(String http) {
     this.http = http;
+    return this;
+  }
+
+  /**
+   * Get header map
+   *
+   * @return header map
+   */
+  public Map<String, List<String>> getHeaders() {
+    return header;
+  }
+
+  /**
+   * Set headers to check
+   *
+   * @param header header map
+   * @return reference to this, for fluency
+   */
+  public CheckOptions setHeaders(Map<String, List<String>> header) {
+    this.header = header;
     return this;
   }
 

--- a/src/main/java/io/vertx/ext/consul/impl/ConsulClientImpl.java
+++ b/src/main/java/io/vertx/ext/consul/impl/ConsulClientImpl.java
@@ -765,6 +765,7 @@ public class ConsulClientImpl implements ConsulClient {
       .put("Notes", checkOptions.getNotes())
       .put("ScriptArgs", checkOptions.getScriptArgs())
       .put("HTTP", checkOptions.getHttp())
+      .put("Header", checkOptions.getHeaders())
       .put("TLSSkipVerify", checkOptions.isTlsSkipVerify())
       .put("GRPC", checkOptions.getGrpc())
       .put("Interval", checkOptions.getInterval())


### PR DESCRIPTION
This is a feature implementation for following issue: https://github.com/vert-x3/vertx-consul-client/issues/76

Note: there is also a small integration test for this feature; 'HttpHealthReporter' class have been made abstract in order to separate two fake check servers (which since this commit extend it), and in one of them ('HttpHealthReporterWithHeaderCheck') to perform a header check.