### PR TITLE
Make the POM work with java 17.0.1+

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -127,7 +127,7 @@
     <profile>
       <id>java-17</id>
       <activation>
-        <jdk>[17,*)</jdk>
+        <jdk>[17,)</jdk>
       </activation>
       <properties>
         <maven.test.skip>true</maven.test.skip>


### PR DESCRIPTION
Change the range for java-17 profile activation to `[17,)`.
According to https://maven.apache.org/enforcer/enforcer-rules/versionRanges.html this is the way to do it and the current way `[17,*)` makes the builds fail

fixes #84

Motivation:

Explain here the context, and why you're making that change, what is the problem you're trying to solve.

Conformance:

Your commits should be signed and you should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
