### PR TITLE
vertx meta data changes final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,21 +54,6 @@
 
     <dependency>
       <groupId>io.vertx</groupId>
-      <artifactId>vertx-codegen-api</artifactId>
-      <optional>true</optional>
-    </dependency>
-    <dependency>
-      <groupId>io.vertx</groupId>
-      <artifactId>vertx-codegen-json</artifactId>
-      <optional>true</optional>
-    </dependency>
-    <dependency>
-      <groupId>io.vertx</groupId>
-      <artifactId>vertx-docgen-api</artifactId>
-      <optional>true</optional>
-    </dependency>
-    <dependency>
-      <groupId>io.vertx</groupId>
       <artifactId>vertx-web-client</artifactId>
     </dependency>
     <dependency>

--- a/src/main/java/io/vertx/ext/consul/Service.java
+++ b/src/main/java/io/vertx/ext/consul/Service.java
@@ -34,7 +34,7 @@ import static io.vertx.ext.consul.impl.Utils.mapStringString;
  * @author <a href="mailto:ruslan.sennov@gmail.com">Ruslan Sennov</a>
  */
 @DataObject
-public class Service {
+public class Service implements TxnResult {
 
   private static final String NODE = "Node";
   private static final String ADDRESS = "Address";
@@ -44,6 +44,8 @@ public class Service {
   private static final String SERVICE_ADDRESS = "ServiceAddress";
   private static final String SERVICE_META = "ServiceMeta";
   private static final String SERVICE_PORT = "ServicePort";
+  private static final String CREATE_INDEX = "CreateIndex";
+  private static final String MODIFY_INDEX = "ModifyIndex";
 
   private String node;
   private String nodeAddress;
@@ -53,6 +55,8 @@ public class Service {
   private String address;
   private Map<String, String> meta;
   private int port;
+  private long createIndex;
+  private long modifyIndex;
 
   /**
    * Default constructor
@@ -74,6 +78,8 @@ public class Service {
     this.address = other.address;
     this.meta = other.meta;
     this.port = other.port;
+    this.createIndex = other.createIndex;
+    this.modifyIndex = other.modifyIndex;
   }
 
   /**
@@ -90,6 +96,8 @@ public class Service {
     this.address = service.getString(SERVICE_ADDRESS);
     this.meta = mapStringString(service.getJsonObject(SERVICE_META));
     this.port = service.getInteger(SERVICE_PORT, 0);
+    this.createIndex = service.getLong(CREATE_INDEX, 0l);
+    this.modifyIndex = service.getLong(MODIFY_INDEX, 0l);
   }
 
   /**
@@ -122,6 +130,12 @@ public class Service {
     }
     if (port != 0) {
       jsonObject.put(SERVICE_PORT, port);
+    }
+    if (createIndex != 0l) {
+      jsonObject.put(CREATE_INDEX, createIndex);
+    }
+    if (modifyIndex != 0l) {
+      jsonObject.put(MODIFY_INDEX, modifyIndex);
     }
     return jsonObject;
   }
@@ -285,6 +299,51 @@ public class Service {
     return this;
   }
 
+  /**
+   * Get the internal index value that represents when the entry was created.
+   *
+   * @return the internal index value that represents when the entry was created.
+   */
+  public long getCreateIndex() {
+    return createIndex;
+  }
+
+  /**
+   * Set the internal index value that represents when the entry was created.
+   *
+   * @param createIndex the internal index value that represents when the entry was created.
+   * @return reference to this, for fluency
+   */
+  public Service setCreateIndex(long createIndex) {
+    this.createIndex = createIndex;
+    return this;
+  }
+
+  /**
+   * Get the last index that modified this key.
+   *
+   * @return the last index that modified this key.
+   */
+  public long getModifyIndex() {
+    return modifyIndex;
+  }
+
+  /**
+   * Set the last index that modified this key.
+   *
+   * @param modifyIndex the last index that modified this key.
+   * @return reference to this, for fluency
+   */
+  public Service setModifyIndex(long modifyIndex) {
+    this.modifyIndex = modifyIndex;
+    return this;
+  }
+
+  @Override
+  public TxnOperationType getOperationType() {
+    return TxnOperationType.SERVICE;
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;
@@ -292,6 +351,8 @@ public class Service {
 
     Service service = (Service) o;
 
+    if (createIndex != service.createIndex) return false;
+    if (modifyIndex != service.modifyIndex) return false;
     if (port != service.port) return false;
     if (node != null ? !node.equals(service.node) : service.node != null) return false;
     if (nodeAddress != null ? !nodeAddress.equals(service.nodeAddress) : service.nodeAddress != null) return false;
@@ -312,6 +373,8 @@ public class Service {
     result = 31 * result + (address != null ? address.hashCode() : 0);
     result = 31 * result + (meta != null ? meta.hashCode() : 0);
     result = 31 * result + port;
+    result = 31 * result + (int) (createIndex ^ (createIndex >>> 32));
+    result = 31 * result + (int) (modifyIndex ^ (modifyIndex >>> 32));
     return result;
   }
 

--- a/src/main/java/io/vertx/ext/consul/ServiceOptions.java
+++ b/src/main/java/io/vertx/ext/consul/ServiceOptions.java
@@ -40,6 +40,8 @@ public class ServiceOptions {
   private int port;
   private CheckOptions checkOptions;
   private List<CheckOptions> checkListOptions;
+  private long createIndex;
+  private long modifyIndex;
 
   /**
    * Default constructor
@@ -61,6 +63,8 @@ public class ServiceOptions {
     this.port = options.port;
     this.checkOptions = options.checkOptions;
     this.checkListOptions = options.checkListOptions;
+    this.createIndex = options.createIndex;
+    this.modifyIndex = options.modifyIndex;
   }
 
   /**
@@ -242,4 +246,45 @@ public class ServiceOptions {
     this.checkListOptions = checkListOptions;
     return this;
   }
+
+  /**
+   * Get the internal index value that represents when the entry was created.
+   *
+   * @return the internal index value that represents when the entry was created.
+   */
+  public long getCreateIndex() {
+    return createIndex;
+  }
+
+  /**
+   * Set the internal index value that represents when the entry was created.
+   *
+   * @param createIndex the internal index value that represents when the entry was created.
+   * @return reference to this, for fluency
+   */
+  public ServiceOptions setCreateIndex(long createIndex) {
+    this.createIndex = createIndex;
+    return this;
+  }
+
+  /**
+   * Get the last index that modified this key.
+   *
+   * @return the last index that modified this key.
+   */
+  public long getModifyIndex() {
+    return modifyIndex;
+  }
+
+  /**
+   * Set the last index that modified this key.
+   *
+   * @param modifyIndex the last index that modified this key.
+   * @return reference to this, for fluency
+   */
+  public ServiceOptions setModifyIndex(long modifyIndex) {
+    this.modifyIndex = modifyIndex;
+    return this;
+  }
+
 }

--- a/src/main/java/io/vertx/ext/consul/TxnOperation.java
+++ b/src/main/java/io/vertx/ext/consul/TxnOperation.java
@@ -16,8 +16,7 @@
 package io.vertx.ext.consul;
 
 /**
- * Represents operation in transaction. Key/Value is the only available operation type,
- * though other types of operations may be added in future versions of Consul to be mixed with key/value operations
+ * Represents operation in transaction. The available operation types are KV and Service
  *
  * @author <a href="mailto:ruslan.sennov@gmail.com">Ruslan Sennov</a>
  */

--- a/src/main/java/io/vertx/ext/consul/TxnOperationType.java
+++ b/src/main/java/io/vertx/ext/consul/TxnOperationType.java
@@ -3,13 +3,13 @@ package io.vertx.ext.consul;
 import io.vertx.codegen.annotations.VertxGen;
 
 /**
- * Represents the type of operation in a transaction. KV is the only available operation type,
- * though other types of operations may be added in future versions of Consul to be mixed with key/value operations
+ * Represents the type of operation in a transaction. The available operation types are KV and Service
  *
  * @author <a href="mailto:ruslan.sennov@gmail.com">Ruslan Sennov</a>
  * @see <a href="https://www.consul.io/docs/agent/http/kv.html#txn">/v1/txn</a> endpoint
  */
 @VertxGen
 public enum TxnOperationType {
-  KV
+  KV,
+  SERVICE
 }

--- a/src/main/java/io/vertx/ext/consul/TxnRequest.java
+++ b/src/main/java/io/vertx/ext/consul/TxnRequest.java
@@ -59,6 +59,14 @@ public class TxnRequest {
             .setIndex(txn.getLong("Index"))
             .setSession(txn.getString("Session"))
             .setType(TxnKVVerb.ofVerb(txn.getString("Verb"))));
+        } else if (obj.containsKey("Service")) {
+          JsonObject txn = obj.getJsonObject("Service");
+          ServiceOptions serviceOptions = new ServiceOptions(txn.getJsonObject("Service"));
+          serviceOptions.setName(txn.getJsonObject("Service").getString("Service"));
+          operations.add(new TxnServiceOperation()
+            .setServiceOptions(serviceOptions)
+            .setNode(txn.getString("Node"))
+            .setType(TxnServiceVerb.ofVerb(txn.getString("Verb"))));
         }
       });
     }
@@ -82,6 +90,16 @@ public class TxnRequest {
           .put("Index", kvOp.getIndex())
           .put("Session", kvOp.getSession());
         arr.add(new JsonObject().put("KV", obj));
+      } else if (op instanceof TxnServiceOperation) {
+        TxnServiceOperation serviceOp = (TxnServiceOperation) op;
+        JsonObject serviceObj = serviceOp.getServiceOptions().toJson();
+        serviceObj.put("Service", serviceObj.getValue("name"));
+        serviceObj.remove("name");
+        JsonObject obj = new JsonObject()
+          .put("Verb", serviceOp.getType().getVerb())
+          .put("Service", serviceObj)
+          .put("Node", serviceOp.getNode());
+        arr.add(new JsonObject().put("Service", obj));
       }
     });
     return new JsonObject().put("operations", arr);

--- a/src/main/java/io/vertx/ext/consul/TxnResponse.java
+++ b/src/main/java/io/vertx/ext/consul/TxnResponse.java
@@ -1,3 +1,4 @@
+
 /*
  * Copyright (c) 2016 The original author or authors
  *
@@ -50,6 +51,10 @@ public class TxnResponse {
         JsonObject obj = (JsonObject) entry;
         if (obj.containsKey("KV")) {
           results.add(new KeyValue(obj.getJsonObject("KV")));
+        } else if (obj.containsKey("Service")) {
+          Service service = new Service(obj.getJsonObject("Service"));
+          service.setName(obj.getJsonObject("Service").getString("Service"));
+          results.add(service);
         }
       });
     }
@@ -68,6 +73,11 @@ public class TxnResponse {
     results.forEach(op -> {
       if (op instanceof KeyValue) {
         jsonResults.add(new JsonObject().put("KV", ((KeyValue) op).toJson()));
+      } else if (op instanceof Service) {
+        JsonObject jsonObject = ((Service) op).toJson();
+        jsonObject.put("Service", jsonObject.getString("ServiceName"));
+        jsonObject.remove("ServiceName");
+        jsonResults.add(new JsonObject().put("Service", jsonObject));
       }
     });
     JsonArray jsonErrors = new JsonArray();

--- a/src/main/java/io/vertx/ext/consul/TxnResult.java
+++ b/src/main/java/io/vertx/ext/consul/TxnResult.java
@@ -16,8 +16,7 @@
 package io.vertx.ext.consul;
 
 /**
- * Represents result of operation. Key/Value is the only available result type,
- * though other types of results may be added in future versions of Consul to be mixed with key/value operations
+ * Represents result of operation. The available operation types are KV and Service
  *
  * @author <a href="mailto:ruslan.sennov@gmail.com">Ruslan Sennov</a>
  */

--- a/src/main/java/io/vertx/ext/consul/TxnServiceOperation.java
+++ b/src/main/java/io/vertx/ext/consul/TxnServiceOperation.java
@@ -1,0 +1,109 @@
+package io.vertx.ext.consul;
+
+import io.vertx.codegen.annotations.DataObject;
+import io.vertx.codegen.annotations.GenIgnore;
+import io.vertx.core.json.JsonObject;
+import io.vertx.codegen.json.annotations.JsonGen;
+
+/**
+ * Holds the operation to apply to the service inside a transaction
+ */
+@DataObject
+@JsonGen(publicConverter = false)
+public class TxnServiceOperation implements TxnOperation {
+
+  private TxnServiceVerb type;
+  private String node;
+  private ServiceOptions serviceOptions;
+
+  /**
+   * Default constructor
+   */
+  public
+  TxnServiceOperation() {
+
+  }
+
+  /**
+   * Constructor from JSON
+   *
+   * @param json the JSON
+   */
+  public TxnServiceOperation(JsonObject json) {
+    TxnServiceOperationConverter.fromJson(json, this);
+  }
+
+  /**
+   * Convert to JSON
+   *
+   * @return the JSON
+   */
+  public JsonObject toJson() {
+    JsonObject jsonObject = new JsonObject();
+    TxnServiceOperationConverter.toJson(this, jsonObject);
+    return jsonObject;
+  }
+
+  /**
+   * Get the type of operation to perform
+   *
+   * @return the type of operation to perform
+   */
+  public TxnServiceVerb getType() {
+    return type;
+  }
+
+  /**
+   * Get the node
+   *
+   * @return the node name
+   */
+  public String getNode() { return node; }
+
+  /**
+   * Get the service
+   *
+   * @return the service
+   */
+  public ServiceOptions getServiceOptions() { return serviceOptions; }
+
+  /**
+   * Set the type of operation to perform
+   *
+   * @param type the type of operation to perform
+   * @return reference to this, for fluency
+   */
+  public TxnServiceOperation setType(TxnServiceVerb type) {
+    this.type = type;
+    return this;
+  }
+
+  /**
+   * Set the node
+   *
+   * @param node
+   * @return reference to this, for fluency
+   */
+  public TxnServiceOperation setNode(String node) {
+    this.node = node;
+    return this;
+  }
+
+  /**
+   * Set the service
+   *
+   * @param serviceOptions
+   * @return  reference to this, for fluency
+   */
+  public TxnServiceOperation setServiceOptions(ServiceOptions serviceOptions) {
+    this.serviceOptions = serviceOptions;
+    return this;
+  }
+
+  @GenIgnore
+  @Override
+  public TxnOperationType getOperationType() {
+    return TxnOperationType.SERVICE;
+  }
+
+}

--- a/src/main/java/io/vertx/ext/consul/TxnServiceVerb.java
+++ b/src/main/java/io/vertx/ext/consul/TxnServiceVerb.java
@@ -1,0 +1,52 @@
+package io.vertx.ext.consul;
+
+/**
+ * Holds the type of Service operation in transaction
+ */
+public enum TxnServiceVerb {
+
+  /**
+   * Sets the service to the given state
+   */
+  SET("set"),
+
+  /**
+   * Sets, but with CAS semantics using the given ModifyIndex
+   */
+  CAS("cas"),
+
+  /**
+   * 	Get the service, fails if it does not exist
+   */
+  GET("get"),
+
+  /**
+   * Delete the service
+   */
+  DELETE("delete"),
+
+  /**
+   * Delete, but with CAS semantics
+   */
+  DELETE_CAS("delete-cas");
+
+  public static TxnServiceVerb ofVerb(String verb) {
+    for (TxnServiceVerb type : values()) {
+      if (type.getVerb().equals(verb)) {
+        return type;
+      }
+    }
+    return null;
+  }
+
+  private final String verb;
+
+  TxnServiceVerb(String verb) {
+    this.verb = verb;
+  }
+
+  public String getVerb() {
+    return verb;
+  }
+
+}

--- a/src/main/java/io/vertx/ext/consul/impl/TxnResponseParser.java
+++ b/src/main/java/io/vertx/ext/consul/impl/TxnResponseParser.java
@@ -33,6 +33,9 @@ class TxnResponseParser {
         if (obj.containsKey("KV")) {
           response.addResult(KVParser.parse(obj.getJsonObject("KV")));
         }
+        else if (obj.containsKey("Service")) {
+          response.addResult(ServiceParser.parseAgentInfo(obj.getJsonObject("Service")));
+        }
       });
     }
     if (json.getValue("Errors") instanceof JsonArray) {

--- a/src/test/java/io/vertx/ext/consul/tests/ConsulTestBase.java
+++ b/src/test/java/io/vertx/ext/consul/tests/ConsulTestBase.java
@@ -68,6 +68,10 @@ public class ConsulTestBase extends VertxTestBase {
     readClient = consul.createClient(vertx, consul.dc().readToken());
   }
 
+  public String getNodeName() {
+    return consul.getConfig("node_name");
+  }
+
   public String createAclToken(String name, String rules) {
     AclPolicy policy = new AclPolicy()
       .setName(name)

--- a/src/test/java/io/vertx/ext/consul/tests/suite/Transactions.java
+++ b/src/test/java/io/vertx/ext/consul/tests/suite/Transactions.java
@@ -16,14 +16,29 @@
 package io.vertx.ext.consul.tests.suite;
 
 import io.vertx.core.Handler;
-import io.vertx.ext.consul.*;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.consul.KeyValue;
+import io.vertx.ext.consul.Service;
+import io.vertx.ext.consul.ServiceOptions;
+import io.vertx.ext.consul.TxnError;
+import io.vertx.ext.consul.TxnKVOperation;
+import io.vertx.ext.consul.TxnKVVerb;
+import io.vertx.ext.consul.TxnOperationType;
+import io.vertx.ext.consul.TxnRequest;
+import io.vertx.ext.consul.TxnResponse;
+import io.vertx.ext.consul.TxnServiceOperation;
+import io.vertx.ext.consul.TxnServiceVerb;
 import io.vertx.ext.consul.tests.ConsulTestBase;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.NoSuchElementException;
 import java.util.stream.Collectors;
 
 /**
@@ -31,6 +46,8 @@ import java.util.stream.Collectors;
  */
 @RunWith(VertxUnitRunner.class)
 public class Transactions extends ConsulTestBase {
+
+  private final String SERVICE_NAME = "service1";
 
   @Test
   public void kvSet(TestContext tc) {
@@ -82,6 +99,326 @@ public class Transactions extends ConsulTestBase {
     });
   }
 
+  @Test
+  public void serviceSet(TestContext tc) {
+    ServiceOptions serviceOptions1 = createServiceOptions("id1", SERVICE_NAME, "10.10.10.10", 8080);
+    ServiceOptions serviceOptions2 = createServiceOptions("id2", SERVICE_NAME, "10.10.10.10", 8081);
+    TxnRequest request = new TxnRequest()
+      .addOperation(new TxnServiceOperation().setNode(getNodeName()).setServiceOptions(serviceOptions1).setType(TxnServiceVerb.SET))
+      .addOperation(new TxnServiceOperation().setNode(getNodeName()).setServiceOptions(serviceOptions2).setType(TxnServiceVerb.SET));
+    writeClient.transaction(request).onComplete(tc.asyncAssertSuccess(response -> {
+      tc.assertEquals(0, response.getErrorsSize());
+      tc.assertEquals(2, response.getResultsSize());
+      List<Service> services = getServices(response);
+      checkService(tc, services, serviceOptions1);
+      checkService(tc, services, serviceOptions2);
+      getRegistrations(tc, SERVICE_NAME, registrations -> {
+        checkService(tc, registrations, serviceOptions1);
+        checkService(tc, registrations, serviceOptions2);
+        writeClient.deregisterService(serviceOptions1.getId()).onComplete(tc.asyncAssertSuccess());
+        writeClient.deregisterService(serviceOptions2.getId()).onComplete(tc.asyncAssertSuccess());
+      });
+    }));
+  }
+
+  @Test
+  public void serviceGet(TestContext tc) {
+    ServiceOptions serviceOptions1 = createServiceOptions("id1", SERVICE_NAME, "10.10.10.11", 8080);
+    ServiceOptions serviceOptions2 = createServiceOptions("id2", SERVICE_NAME, "10.10.10.11", 8081);
+    TxnRequest getRequest = new TxnRequest()
+      .addOperation(new TxnServiceOperation().setNode(getNodeName()).setServiceOptions(serviceOptions1).setType(TxnServiceVerb.GET))
+      .addOperation(new TxnServiceOperation().setNode(getNodeName()).setServiceOptions(serviceOptions2).setType(TxnServiceVerb.GET));
+    writeClient.transaction(getRequest).onComplete(tc.asyncAssertSuccess(resp1 -> {
+      tc.assertEquals(2, resp1.getErrorsSize());
+      tc.assertEquals(0, resp1.getResultsSize());
+      registerServiceAndGet(tc, serviceOptions1, getRequest, resp2 -> {
+        tc.assertEquals(1, resp2.getErrorsSize());
+        tc.assertEquals(0, resp2.getResultsSize());
+        registerServiceAndGet(tc, serviceOptions2, getRequest, resp3 -> {
+          tc.assertEquals(0, resp3.getErrorsSize());
+          tc.assertEquals(2, resp3.getResultsSize());
+          List<Service> services = getServices(resp3);
+          checkService(tc, services, serviceOptions1);
+          checkService(tc, services, serviceOptions2);
+          writeClient.deregisterCatalogService(getNodeName(), serviceOptions1.getId()).onComplete(tc.asyncAssertSuccess());
+          writeClient.deregisterCatalogService(getNodeName(), serviceOptions2.getId()).onComplete(tc.asyncAssertSuccess());
+        });
+      });
+    }));
+  }
+
+  @Test
+  public void serviceDelete(TestContext tc) {
+    ServiceOptions serviceOptions1 = createServiceOptions("id1", SERVICE_NAME, "10.10.10.10", 8080);
+    ServiceOptions serviceOptions2 = createServiceOptions("id2", SERVICE_NAME, "10.10.10.10", 8081);
+    TxnRequest deleteRequest = new TxnRequest()
+      .addOperation(new TxnServiceOperation().setNode(getNodeName()).setServiceOptions(serviceOptions1).setType(TxnServiceVerb.DELETE))
+      .addOperation(new TxnServiceOperation().setNode(getNodeName()).setServiceOptions(serviceOptions2).setType(TxnServiceVerb.DELETE));
+    writeClient.transaction(deleteRequest).onComplete(tc.asyncAssertSuccess(resp1 -> {
+      tc.assertEquals(0, resp1.getErrorsSize());
+      tc.assertEquals(0, resp1.getResultsSize());
+      writeClient.registerService(serviceOptions1).onComplete(tc.asyncAssertSuccess(resp2 -> {
+        getRegistrations(tc, SERVICE_NAME, registrations1 -> {
+          checkService(tc, registrations1, serviceOptions1);
+          writeClient.transaction(deleteRequest).onComplete(tc.asyncAssertSuccess(resp3 -> {
+            tc.assertEquals(0, resp1.getErrorsSize());
+            tc.assertEquals(0, resp1.getResultsSize());
+            getRegistrations(tc, SERVICE_NAME, registrations2 -> {
+              tc.assertEquals(0, registrations2.size());
+            });
+          }));
+        });
+      }));
+    }));
+  }
+
+  @Test
+  public void serviceCas(TestContext tc) {
+    ServiceOptions serviceOptions1 = createServiceOptions("id1", SERVICE_NAME, "10.10.10.10", 8080);
+    ServiceOptions serviceOptions2 = createServiceOptions("id2", SERVICE_NAME, "10.10.10.10", 8081);
+    Map<String, String> meta = new HashMap<>();
+    meta.put("test1", "value2");
+    writeClient.registerService(serviceOptions1).onComplete(tc.asyncAssertSuccess(resp1 -> {
+      writeClient.registerService(serviceOptions2).onComplete(tc.asyncAssertSuccess(resp2 -> {
+        getRegistrations(tc, SERVICE_NAME, registrations1 -> {
+          long idx1 = getModifyIndex(tc, registrations1, serviceOptions1);
+          long idx2 = getModifyIndex(tc, registrations1, serviceOptions2);
+          TxnRequest requestWithStaleIndex = new TxnRequest()
+            .addOperation(new TxnServiceOperation().setNode(getNodeName()).setType(TxnServiceVerb.CAS).setServiceOptions(
+              serviceOptions1.setMeta(meta).setModifyIndex(idx1 - 1)))
+            .addOperation(new TxnServiceOperation().setNode(getNodeName()).setType(TxnServiceVerb.CAS).setServiceOptions(
+              serviceOptions2.setMeta(meta).setModifyIndex(idx2)));
+          writeClient.transaction(requestWithStaleIndex).onComplete(tc.asyncAssertSuccess(resp3 -> {
+            tc.assertEquals(1, resp3.getErrorsSize());
+            tc.assertEquals(0, resp3.getResultsSize());
+            TxnRequest request = new TxnRequest()
+              .addOperation(new TxnServiceOperation().setNode(getNodeName()).setType(TxnServiceVerb.CAS).setServiceOptions(
+                serviceOptions1.setMeta(meta).setModifyIndex(idx1)))
+              .addOperation(new TxnServiceOperation().setNode(getNodeName()).setType(TxnServiceVerb.CAS).setServiceOptions(
+                serviceOptions2.setMeta(meta).setModifyIndex(idx2)));
+            writeClient.transaction(request).onComplete(tc.asyncAssertSuccess(resp4 -> {
+              tc.assertEquals(0, resp4.getErrorsSize());
+              tc.assertEquals(2, resp4.getResultsSize());
+              getRegistrations(tc, SERVICE_NAME, registrations2 -> {
+                checkService(tc, registrations2, serviceOptions1);
+                checkService(tc, registrations2, serviceOptions2);
+                writeClient.deregisterCatalogService(getNodeName(), serviceOptions1.getId()).onComplete(tc.asyncAssertSuccess());
+                writeClient.deregisterCatalogService(getNodeName(), serviceOptions2.getId()).onComplete(tc.asyncAssertSuccess());
+              });
+            }));
+          }));
+        });
+      }));
+    }));
+  }
+
+  @Test
+  public void serviceMultiOperationSuccess(TestContext tc) {
+    ServiceOptions serviceOptions1 = createServiceOptions("id1", SERVICE_NAME, "10.10.10.10", 8080);
+    ServiceOptions serviceOptions2 = createServiceOptions("id2", SERVICE_NAME, "10.10.10.10", 8081);
+    ServiceOptions serviceOptions3 = createServiceOptions("id3", SERVICE_NAME, "10.10.10.10", 8082);
+    writeClient.registerService(serviceOptions1).onComplete(tc.asyncAssertSuccess(resp1 -> {
+      writeClient.registerService(serviceOptions2).onComplete(tc.asyncAssertSuccess(resp2 -> {
+        getRegistrations(tc, SERVICE_NAME, registrations1 -> {
+          tc.assertEquals(2, registrations1.size());
+          Map<String, String> meta = new HashMap<>();
+          meta.put("test2", "value2");
+          serviceOptions2.setMeta(meta);
+          TxnRequest multiOpRequest = new TxnRequest()
+            .addOperation(new TxnServiceOperation().setNode(getNodeName()).setServiceOptions(serviceOptions1).setType(TxnServiceVerb.DELETE))
+            .addOperation(new TxnServiceOperation().setNode(getNodeName()).setServiceOptions(serviceOptions2).setType(TxnServiceVerb.SET))
+            .addOperation(new TxnServiceOperation().setNode(getNodeName()).setServiceOptions(serviceOptions3).setType(TxnServiceVerb.SET));
+          writeClient.transaction(multiOpRequest).onComplete(tc.asyncAssertSuccess(resp3 -> {
+            tc.assertEquals(0, resp3.getErrorsSize());
+            tc.assertEquals(2, resp3.getResultsSize());
+            getRegistrations(tc, SERVICE_NAME, registrations2 -> {
+              tc.assertEquals(2, registrations2.size());
+              checkService(tc, registrations2, serviceOptions2);
+              checkService(tc, registrations2, serviceOptions3);
+              writeClient.deregisterCatalogService(getNodeName(), serviceOptions2.getId()).onComplete(tc.asyncAssertSuccess());
+              writeClient.deregisterCatalogService(getNodeName(), serviceOptions3.getId()).onComplete(tc.asyncAssertSuccess());
+            });
+          }));
+        });
+      }));
+    }));
+  }
+
+  @Test
+  public void serviceMultiOperationError(TestContext tc) {
+    ServiceOptions serviceOptions1 = createServiceOptions("id1", SERVICE_NAME, "10.10.12.10", 8080);
+    ServiceOptions serviceOptions2 = createServiceOptions("id2", SERVICE_NAME, "10.10.12.10", 8081);
+    ServiceOptions serviceOptions3 = createServiceOptions("id3", "", "10.10.12.10", 8082);
+    writeClient.registerService(serviceOptions1).onComplete(tc.asyncAssertSuccess(resp1 -> {
+      writeClient.registerService(serviceOptions2).onComplete(tc.asyncAssertSuccess(resp2 -> {
+        getRegistrations(tc, SERVICE_NAME, registrations1 -> {
+          checkService(tc, registrations1, serviceOptions1);
+          checkService(tc, registrations1, serviceOptions2);
+          TxnRequest multiOpRequest = new TxnRequest()
+            .addOperation(new TxnServiceOperation().setNode(getNodeName()).setServiceOptions(serviceOptions1).setType(TxnServiceVerb.DELETE))
+            .addOperation(new TxnServiceOperation().setNode(getNodeName()).setServiceOptions(serviceOptions2).setType(TxnServiceVerb.GET))
+            .addOperation(new TxnServiceOperation().setNode(getNodeName()).setServiceOptions(serviceOptions3).setType(TxnServiceVerb.SET));
+          writeClient.transaction(multiOpRequest).onComplete(tc.asyncAssertSuccess(resp3 -> {
+            tc.assertEquals(1, resp3.getErrorsSize());
+            tc.assertEquals(2, resp3.getError(0).getOpIndex());
+            tc.assertEquals(0, resp3.getResultsSize());
+            getRegistrations(tc, SERVICE_NAME, registrations2 -> {
+              tc.assertEquals(2, registrations2.size());
+              checkService(tc, registrations2, serviceOptions1);
+              checkService(tc, registrations2, serviceOptions2);
+              writeClient.deregisterCatalogService(getNodeName(), serviceOptions1.getId()).onComplete(tc.asyncAssertSuccess());
+              writeClient.deregisterCatalogService(getNodeName(), serviceOptions2.getId()).onComplete(tc.asyncAssertSuccess());
+            });
+          }));
+        });
+      }));
+    }));
+  }
+
+  @Test
+  public void kvAndServiceSet(TestContext tc) {
+    ServiceOptions serviceOptions = createServiceOptions("id1", SERVICE_NAME, "10.10.10.10", 8080);
+    TxnRequest request = new TxnRequest()
+      .addOperation(new TxnKVOperation().setKey("foo/bar/t1").setValue("val1").setType(TxnKVVerb.SET))
+      .addOperation(new TxnKVOperation().setKey("foo/bar/t2").setValue("val2").setType(TxnKVVerb.SET))
+      .addOperation(new TxnServiceOperation().setNode(getNodeName()).setServiceOptions(serviceOptions).setType(TxnServiceVerb.SET));
+    writeClient.transaction(request).onComplete(tc.asyncAssertSuccess(response -> {
+      tc.assertEquals(0, response.getErrorsSize());
+      tc.assertEquals(3, response.getResultsSize());
+      List<String> keys = getKeys(response);
+      tc.assertTrue(keys.contains("foo/bar/t1"));
+      tc.assertTrue(keys.contains("foo/bar/t2"));
+      List<Service> services = getServices(response);
+      checkService(tc, services, serviceOptions);
+      getEntries(tc, "foo/bar/t", entries -> {
+        tc.assertTrue(entries.contains("foo/bar/t1/val1"));
+        tc.assertTrue(entries.contains("foo/bar/t2/val2"));
+        writeClient.deleteValues("foo/bar/t").onComplete(tc.asyncAssertSuccess());
+        getRegistrations(tc, SERVICE_NAME, registrations2 -> {
+          checkService(tc, registrations2, serviceOptions);;
+          writeClient.deregisterCatalogService(getNodeName(), serviceOptions.getId()).onComplete(tc.asyncAssertSuccess());
+        });
+      });
+    }));
+  }
+
+  @Test
+  public void kvAndServiceError(TestContext tc) {
+    ServiceOptions serviceOptions = createServiceOptions("id1", SERVICE_NAME, "10.10.10.10", 8080);
+    TxnRequest request = new TxnRequest()
+      .addOperation(new TxnKVOperation().setKey("foo/bar/t1").setValue("val1").setType(TxnKVVerb.SET))
+      .addOperation(new TxnKVOperation().setKey("foo/bar/t2").setValue("val2").setType(TxnKVVerb.SET))
+      .addOperation(new TxnServiceOperation().setNode(getNodeName()).setServiceOptions(serviceOptions).setType(TxnServiceVerb.GET));
+    writeClient.transaction(request).onComplete(tc.asyncAssertSuccess(response -> {
+      tc.assertEquals(1, response.getErrorsSize());
+      tc.assertEquals(2, response.getError(0).getOpIndex());
+      tc.assertEquals(0, response.getResultsSize());
+      List<String> keys = getKeys(response);
+      tc.assertTrue(keys.isEmpty());
+      List<Service> services = getServices(response);
+      tc.assertTrue(services.isEmpty());
+      readClient.getValues("foo/bar/t").onComplete(tc.asyncAssertSuccess(entries -> {
+        tc.assertTrue(entries.getList() == null);
+      }));
+    }));
+  }
+
+  @Test
+  public void testJsonToTxnRequest(TestContext tc) {
+    ServiceOptions serviceOptions = createServiceOptions("id1", SERVICE_NAME, "10.10.10.10", 8080);
+    Map<String, String> meta = new HashMap<>();
+    meta.put("test1", "value2");
+    List<String> tags = new ArrayList<>();
+    tags.add("tag1");
+    serviceOptions.setMeta(meta);
+    serviceOptions.setTags(tags);
+    TxnRequest txnRequest = new TxnRequest()
+      .addOperation(new TxnKVOperation().setKey("foo/bar/t1").setValue("val1").setType(TxnKVVerb.SET))
+      .addOperation(new TxnServiceOperation().setNode(getNodeName()).setServiceOptions(serviceOptions).setType(TxnServiceVerb.SET));
+    JsonObject jsonRequest = txnRequest.toJson();
+    List<JsonObject> jsonOperations = jsonRequest.getJsonArray("operations").getList();
+    tc.assertEquals(serviceOptions.getName(), jsonOperations.get(1).getJsonObject("Service").getJsonObject("Service").getString("Service"));
+    TxnRequest deserializedTxnRequest = new TxnRequest(jsonRequest);
+    tc.assertTrue(deserializedTxnRequest.getOperations().get(0) instanceof TxnKVOperation);
+    TxnKVOperation deserializedTxnKVOperation = (TxnKVOperation) deserializedTxnRequest.getOperations().get(0);
+    tc.assertEquals("foo/bar/t1", deserializedTxnKVOperation.getKey());
+    tc.assertEquals("val1", deserializedTxnKVOperation.getValue());
+    tc.assertEquals(TxnKVVerb.SET, deserializedTxnKVOperation.getType());
+    tc.assertEquals(TxnOperationType.KV, deserializedTxnKVOperation.getOperationType());
+    tc.assertTrue(deserializedTxnRequest.getOperations().get(1) instanceof TxnServiceOperation);
+    TxnServiceOperation deserializedTxnServiceOperation = (TxnServiceOperation) deserializedTxnRequest.getOperations().get(1);
+    tc.assertEquals(getNodeName(), deserializedTxnServiceOperation.getNode());
+    tc.assertEquals(TxnServiceVerb.SET, deserializedTxnServiceOperation.getType());
+    tc.assertEquals(TxnOperationType.SERVICE, deserializedTxnServiceOperation.getOperationType());
+    ServiceOptions deserializedServiceOptions = deserializedTxnServiceOperation.getServiceOptions();
+    tc.assertEquals(serviceOptions.getId(), deserializedServiceOptions.getId());
+    tc.assertEquals(serviceOptions.getName(), deserializedServiceOptions.getName());
+    tc.assertEquals(serviceOptions.getAddress(), deserializedServiceOptions.getAddress());
+    tc.assertEquals(serviceOptions.getPort(), deserializedServiceOptions.getPort());
+    tc.assertEquals(serviceOptions.getTags(), deserializedServiceOptions.getTags());
+    tc.assertEquals(serviceOptions.getMeta(), deserializedServiceOptions.getMeta());
+    tc.assertEquals(serviceOptions.getCreateIndex(), deserializedServiceOptions.getCreateIndex());
+    tc.assertEquals(serviceOptions.getModifyIndex(), deserializedServiceOptions.getModifyIndex());
+  }
+
+  @Test
+  public void testJsonToTxnResponse(TestContext tc) {
+    List<String> tags = new ArrayList<>();
+    tags.add("tag1");
+    Map<String, String> meta = new HashMap<>();
+    meta.put("test1", "value2");
+    Service service = new Service()
+      .setId("id1")
+      .setName(SERVICE_NAME)
+      .setAddress("10.10.10.10")
+      .setPort(8080)
+      .setMeta(meta)
+      .setTags(tags);
+    KeyValue keyValue = new KeyValue()
+      .setKey("foo/bar/t1")
+      .setValue("val1");
+    TxnError txnError = new TxnError()
+      .setOpIndex(0)
+      .setWhat("Missing node registration");
+    TxnResponse txnResponse = new TxnResponse()
+      .addResult(keyValue)
+      .addResult(service)
+      .addError(txnError);
+    JsonObject jsonObject = txnResponse.toJson();
+    List<JsonObject> jsonResults = jsonObject.getJsonArray("Results").getList();
+    tc.assertEquals(service.getName(), jsonResults.get(1).getJsonObject("Service").getString("Service"));
+    TxnResponse deserializedTxnResponse = new TxnResponse(jsonObject);
+    tc.assertEquals(deserializedTxnResponse.getResultsSize(), 2);
+    tc.assertTrue(deserializedTxnResponse.getResults().get(0) instanceof KeyValue);
+    KeyValue deserializedKeyValue = (KeyValue) deserializedTxnResponse.getResults().get(0);
+    tc.assertEquals(keyValue.getKey(), deserializedKeyValue.getKey());
+    tc.assertEquals(keyValue.getValue(), deserializedKeyValue.getValue());
+    tc.assertTrue(deserializedTxnResponse.getResults().get(1) instanceof Service);
+    Service deserializedService = (Service) deserializedTxnResponse.getResults().get(1);
+    tc.assertEquals(service.getId(), deserializedService.getId());
+    tc.assertEquals(service.getName(), deserializedService.getName());
+    tc.assertEquals(service.getAddress(), deserializedService.getAddress());
+    tc.assertEquals(service.getPort(), deserializedService.getPort());
+    tc.assertEquals(service.getTags(), deserializedService.getTags());
+    tc.assertEquals(service.getMeta(), deserializedService.getMeta());
+    tc.assertEquals(service.getCreateIndex(), deserializedService.getCreateIndex());
+    tc.assertEquals(service.getModifyIndex(), deserializedService.getModifyIndex());
+    tc.assertEquals(deserializedTxnResponse.getErrorsSize(), 1);
+    tc.assertTrue(deserializedTxnResponse.getErrors().get(0) instanceof TxnError);
+    TxnError deserializedTxnError = deserializedTxnResponse.getErrors().get(0);
+    tc.assertEquals(txnError.getOpIndex(), deserializedTxnError.getOpIndex());
+    tc.assertEquals(txnError.getWhat(), deserializedTxnError.getWhat());
+  }
+
+  @Test
+  public void testEmptyJsonToTxnResponse(TestContext tc) {
+    TxnResponse txnResponse = new TxnResponse();
+    JsonObject jsonObject = txnResponse.toJson();
+    TxnResponse deserializedTxnResponse = new TxnResponse(jsonObject);
+    tc.assertEquals(deserializedTxnResponse.getResultsSize(), 0);
+    tc.assertEquals(deserializedTxnResponse.getErrorsSize(), 0);
+  }
+
   private void getEntries(TestContext tc, String prefix, Handler<List<String>> resultHandler) {
     readClient.getValues(prefix).onComplete(tc.asyncAssertSuccess(list -> {
       resultHandler.handle(list.getList().stream()
@@ -91,6 +428,7 @@ public class Transactions extends ConsulTestBase {
 
   private List<String> getKeys(TxnResponse resp) {
     return resp.getResults().stream()
+      .filter(o -> o instanceof KeyValue)
       .map(kv -> ((KeyValue) kv).getKey()).collect(Collectors.toList());
   }
 
@@ -102,4 +440,62 @@ public class Transactions extends ConsulTestBase {
       }));
     }));
   }
+
+  private void getRegistrations(TestContext tc, String serviceName, Handler<List<Service>> resultHandler) {
+    readClient.catalogServiceNodes(serviceName).onComplete(tc.asyncAssertSuccess(list -> {
+      resultHandler.handle(list.getList());
+    }));
+  }
+
+  private List<Service> getServices(TxnResponse resp) {
+    return resp.getResults().stream()
+      .filter(o -> o instanceof Service)
+      .map(s -> ((Service) s)).collect(Collectors.toList());
+  }
+
+  private ServiceOptions createServiceOptions(String id, String name, String address, int port) {
+    Map<String, String> meta = new HashMap<>();
+    meta.put("test1", "value1");
+    List<String> tags = new ArrayList<>();
+    tags.add("TAG_1");
+    tags.add("TAG_2");
+    return new ServiceOptions()
+      .setId(id)
+      .setName(name)
+      .setAddress(address)
+      .setPort(port)
+      .setMeta(meta)
+      .setTags(tags);
+  }
+
+  private static void checkService(TestContext tc, List<Service> list, ServiceOptions options) {
+    Service s = list.stream()
+      .filter(i -> i.getId().equals(options.getId()))
+      .findFirst()
+      .orElseThrow(NoSuchElementException::new);
+    tc.assertEquals(s.getName(), options.getName());
+    tc.assertEquals(s.getTags(), options.getTags());
+    tc.assertEquals(s.getAddress(), options.getAddress());
+    tc.assertEquals(s.getPort(), options.getPort());
+    for (Map.Entry<String, String> entry : options.getMeta().entrySet()) {
+      tc.assertEquals(s.getMeta().get(entry.getKey()), entry.getValue());
+    }
+  }
+
+  private long getModifyIndex(TestContext tc, List<Service> list, ServiceOptions options) {
+    Service s = list.stream()
+      .filter(i -> i.getId().equals(options.getId()))
+      .findFirst()
+      .orElseThrow(NoSuchElementException::new);
+    return s.getModifyIndex();
+  }
+
+  private void registerServiceAndGet(TestContext tc, ServiceOptions serviceOptions, TxnRequest txnRequest, Handler<TxnResponse> resultsHandler) {
+    writeClient.registerService(serviceOptions).onComplete(tc.asyncAssertSuccess(resp1 -> {
+      writeClient.transaction(txnRequest).onComplete(tc.asyncAssertSuccess(resp2 -> {
+        resultsHandler.handle(resp2);
+      }));
+    }));
+  }
+
 }


### PR DESCRIPTION
The changes made to the vertx consul client for the extended meta data changes

Motivation:

If there was an external service that needed to register more than 64 meta data entries (for routing i.e. IPv6 prefix ranges), the NFRA would simply fail to register that service instance.

Solution
If the NFRA detects that more than 64 meta data entries are needed, then all meta data is stored in a KV entry, rather than the service instance meta data storage.
The service instance meta data storage has a single entry, which points to the KV store entry key, holding the actual meta data.