### PR TITLE
Add spotless plugin and remove unused imports

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -100,6 +100,16 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>com.diffplug.spotless</groupId>
+        <artifactId>spotless-maven-plugin</artifactId>
+        <version>3.5.1</version>
+        <configuration>
+          <java>
+            <removeUnusedImports />
+          </java>
+        </configuration>
+      </plugin>
+      <plugin>
         <artifactId>maven-assembly-plugin</artifactId>
         <executions>
           <execution>

--- a/src/main/java/io/vertx/ext/consul/Service.java
+++ b/src/main/java/io/vertx/ext/consul/Service.java
@@ -20,10 +20,8 @@ import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 import static io.vertx.ext.consul.impl.Utils.listOf;
 import static io.vertx.ext.consul.impl.Utils.mapStringString;

--- a/src/main/java/io/vertx/ext/consul/impl/EventParser.java
+++ b/src/main/java/io/vertx/ext/consul/impl/EventParser.java
@@ -18,8 +18,6 @@ package io.vertx.ext.consul.impl;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.consul.Event;
 
-import java.util.Base64;
-
 /**
  * @author <a href="mailto:ruslan.sennov@gmail.com">Ruslan Sennov</a>
  */

--- a/src/main/java/io/vertx/ext/consul/impl/KVParser.java
+++ b/src/main/java/io/vertx/ext/consul/impl/KVParser.java
@@ -18,8 +18,6 @@ package io.vertx.ext.consul.impl;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.consul.KeyValue;
 
-import java.util.Base64;
-
 /**
  * @author <a href="mailto:ruslan.sennov@gmail.com">Ruslan Sennov</a>
  */

--- a/src/main/java/io/vertx/ext/consul/impl/Query.java
+++ b/src/main/java/io/vertx/ext/consul/impl/Query.java
@@ -15,9 +15,7 @@
  */
 package io.vertx.ext.consul.impl;
 
-import io.vertx.core.buffer.Buffer;
 import io.vertx.ext.consul.BlockingQueryOptions;
-import io.vertx.ext.web.client.HttpRequest;
 
 import java.util.HashMap;
 import java.util.Map;

--- a/src/test/java/io/vertx/ext/consul/tests/Utils.java
+++ b/src/test/java/io/vertx/ext/consul/tests/Utils.java
@@ -15,9 +15,7 @@
  */
 package io.vertx.ext.consul.tests;
 
-import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
-import io.vertx.core.Handler;
 import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
 
@@ -29,7 +27,6 @@ import java.net.ServerSocket;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BiConsumer;
-import java.util.function.Consumer;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 


### PR DESCRIPTION
Added spotless plugin to remove unused imports. I have just added the goal of removing unused imports, this can be further extended to impose a code style, import order etc.

cc @vietj I believe this will help with checks. You can use goal = `spotless:apply` to remove unused imports now.