### PR TITLE
Fix Catalog test

### DIFF
--- a/src/test/java/io/vertx/ext/consul/tests/suite/Catalog.java
+++ b/src/test/java/io/vertx/ext/consul/tests/suite/Catalog.java
@@ -51,9 +51,12 @@ public class Catalog extends ConsulTestBase {
   @Test
   public void nodes(TestContext tc) {
     readClient.catalogNodes().onComplete(tc.asyncAssertSuccess(nodes -> {
-      tc.assertEquals(nodes.getList().size(), 1);
-      Node node = nodes.getList().get(0);
-      tc.assertEquals(node.getName(), consul.getConfig("node_name"));
+      for (Node node : nodes.getList()) {
+        if (node.getName().equals(consul.getConfig("node_name"))) {
+          return;
+        }
+      }
+      tc.fail("Could not find the node in the catalog");
     }));
   }
 


### PR DESCRIPTION
More often than not, there are several nodes in the catalog. Instead of expecting a single node, we should relax the test and just make sure the node is present.